### PR TITLE
add pkgdown website to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,8 @@ Authors@R: c(
   )
 Description: This is a pkgdown template intended to be used for pkgdown sites created for RMI PACTA R packages.
 License: MIT + file LICENSE
-URL: https://github.com/rmi-pacta/pacta.pkgdown.rmitemplate
+URL: https://rmi-pacta.github.io/pacta.pkgdown.rmitemplate,
+     https://github.com/rmi-pacta/pacta.pkgdown.rmitemplate
 BugReports: https://github.com/rmi-pacta/pacta.pkgdown.rmitemplate/issues
 Encoding: UTF-8
 Config/Needs/website: rmi-pacta/pacta.pkgdown.rmitemplate


### PR DESCRIPTION
avoids pkgdown warning...
```
✖ URLs not ok.
  In DESCRIPTION, URL is missing package url
  (https://rmi-pacta.github.io/pacta.pkgdown.rmitemplate).
  See details in `vignette(pkgdown::metadata)`.
```